### PR TITLE
Add three card spread feature

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,13 +9,28 @@
 <body>
     <div id="app">
         <h1>Afrikan Tarot Reading</h1>
-        <button id="drawCard">Draw Card</button>
-        <div id="cardContainer" class="hidden">
-            <img id="cardImage" src="" alt="Card" />
-            <p id="cardName"></p>
-            <audio id="cardSound"></audio>
-            <div id="interpretation"></div>
+        <button id="drawCards">Draw Cards</button>
+        <div id="threeCardContainer" class="hidden">
+            <div class="slot">
+                <h3>Past</h3>
+                <img id="pastImage" src="" alt="Past Card" />
+                <p id="pastName"></p>
+                <div id="pastInterpretation" class="interpretation"></div>
+            </div>
+            <div class="slot">
+                <h3>Present</h3>
+                <img id="presentImage" src="" alt="Present Card" />
+                <p id="presentName"></p>
+                <div id="presentInterpretation" class="interpretation"></div>
+            </div>
+            <div class="slot">
+                <h3>Future</h3>
+                <img id="futureImage" src="" alt="Future Card" />
+                <p id="futureName"></p>
+                <div id="futureInterpretation" class="interpretation"></div>
+            </div>
         </div>
+        <audio id="cardSound"></audio>
     </div>
     <script type="module" src="main.js"></script>
 </body>

--- a/main.js
+++ b/main.js
@@ -12,22 +12,37 @@ function playSound(url) {
     audio.play();
 }
 
-function displayCard(card) {
-    const container = document.getElementById('cardContainer');
-    document.getElementById('cardImage').src = card.image;
-    document.getElementById('cardName').textContent = card.name;
+async function displaySlot(slot, card) {
+    const container = document.getElementById('threeCardContainer');
+    document.getElementById(`${slot}Image`).src = card.image;
+    document.getElementById(`${slot}Name`).textContent = card.name;
     playSound(card.sound);
+    const interpretation = await getInterpretation(card);
+    const interpEl = document.getElementById(`${slot}Interpretation`);
+    if (interpEl) {
+        interpEl.textContent = interpretation;
+    }
     container.classList.remove('hidden');
 }
 
-async function drawCard(cards) {
-    const card = cards[Math.floor(Math.random() * cards.length)];
-    displayCard(card);
-    const interpretation = await getInterpretation(card);
-    document.getElementById('interpretation').textContent = interpretation;
+async function drawCards(cards) {
+    const used = new Set();
+    const drawn = [];
+    while (drawn.length < 3) {
+        const idx = Math.floor(Math.random() * cards.length);
+        if (!used.has(idx)) {
+            used.add(idx);
+            drawn.push(cards[idx]);
+        }
+    }
+    await Promise.all([
+        displaySlot('past', drawn[0]),
+        displaySlot('present', drawn[1]),
+        displaySlot('future', drawn[2])
+    ]);
 }
 
 window.addEventListener('DOMContentLoaded', async () => {
     const cards = await loadCards();
-    document.getElementById('drawCard').addEventListener('click', () => drawCard(cards));
+    document.getElementById('drawCards').addEventListener('click', () => drawCards(cards));
 });

--- a/style.css
+++ b/style.css
@@ -27,17 +27,20 @@ button:hover {
     transform: scale(1.05);
 }
 
-#cardContainer {
+#threeCardContainer {
     margin-top: 20px;
     animation: fadeIn 1s forwards;
+    display: flex;
+    justify-content: center;
+    gap: 20px;
 }
 
-#cardContainer.hidden {
+#threeCardContainer.hidden {
     display: none;
 }
 
-#cardImage {
-    width: 300px;
+.slot img {
+    width: 200px;
     height: auto;
     box-shadow: 0 4px 6px rgba(0,0,0,0.3);
     border-radius: 10px;


### PR DESCRIPTION
## Summary
- allow drawing three cards instead of one
- show Past, Present and Future slots in the UI
- layout new slots with flexbox

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686dcb029d5083258b9c4b7aa11f09f1