### PR TITLE
Add animation and cleanup markup

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,42 +10,24 @@
 <body>
     <div id="app">
         <h1>Afrikan Tarot Reading</h1>
- e7y89c-codex/add-draw-3-cards-functionality
         <p id="intro">Focus on your question and draw three cards.</p>
-        <button id="drawCards">Draw Cards</button>
-        <div id="threeCardContainer">
-            <div class="slot">
-                <img id="pastImage" src="" alt="Past Card" />
-                <p class="slotLabel">Past</p>
-
         <button id="drawCards">Draw Cards</button>
         <div id="threeCardContainer" class="hidden">
             <div class="slot">
                 <h3>Past</h3>
                 <img id="pastImage" src="" alt="Past Card" />
- main
                 <p id="pastName"></p>
                 <div id="pastInterpretation" class="interpretation"></div>
             </div>
             <div class="slot">
- e7y89c-codex/add-draw-3-cards-functionality
-                <img id="presentImage" src="" alt="Present Card" />
-                <p class="slotLabel">Present</p>
-
                 <h3>Present</h3>
                 <img id="presentImage" src="" alt="Present Card" />
- main
                 <p id="presentName"></p>
                 <div id="presentInterpretation" class="interpretation"></div>
             </div>
             <div class="slot">
-
-                <img id="futureImage" src="" alt="Future Card" />
-                <p class="slotLabel">Future</p>
-
                 <h3>Future</h3>
                 <img id="futureImage" src="" alt="Future Card" />
- main
                 <p id="futureName"></p>
                 <div id="futureInterpretation" class="interpretation"></div>
             </div>

--- a/main.js
+++ b/main.js
@@ -20,23 +20,45 @@ function playSound(url) {
     audio.play();
 }
 
+function resetSlots() {
+    const container = document.getElementById('threeCardContainer');
+    container.classList.remove('with-background');
+    container.style.backgroundImage = '';
+    ['past', 'present', 'future'].forEach(slot => {
+        const img = document.getElementById(`${slot}Image`);
+        img.src = '';
+        img.className = '';
+        document.getElementById(`${slot}Name`).textContent = '';
+        const interp = document.getElementById(`${slot}Interpretation`);
+        if (interp) interp.textContent = '';
+    });
+}
+
 async function displaySlot(slot, card) {
     const container = document.getElementById('threeCardContainer');
-    document.getElementById(`${slot}Image`).src = card.image;
+    const imgEl = document.getElementById(`${slot}Image`);
+    imgEl.src = card.image;
+    imgEl.classList.add('drawn');
     document.getElementById(`${slot}Name`).textContent = card.name;
- e7y89c-codex/add-draw-3-cards-functionality
-
     playSound(card.sound);
-main
+
     const interpretation = await getInterpretation(card);
     const interpEl = document.getElementById(`${slot}Interpretation`);
     if (interpEl) {
         interpEl.textContent = interpretation;
     }
+
+    if (slot === 'present') {
+        imgEl.classList.add('center');
+        container.style.backgroundImage = `url('${card.image}')`;
+        container.classList.add('with-background');
+    }
+
     container.classList.remove('hidden');
 }
 
 async function drawCards(cards) {
+    resetSlots();
     const used = new Set();
     const drawn = [];
     while (drawn.length < 3) {

--- a/style.css
+++ b/style.css
@@ -36,31 +36,32 @@ button:hover {
     gap: 20px;
 }
 
- e7y89c-codex/add-draw-3-cards-functionality
+#threeCardContainer.hidden {
+    display: none;
+}
+
+#threeCardContainer.with-background {
+    background-size: cover;
+    background-position: center;
+    padding: 20px;
+    border-radius: 10px;
+}
+
 .slot {
     background-color: rgba(0, 0, 0, 0.3);
     padding: 10px;
     border-radius: 8px;
 }
 
-.interpretation {
-    margin-top: 10px;
-    font-size: 0.9em;
-}
-
-=======
- main
-#threeCardContainer.hidden {
-    display: none;
-}
-
 .slot img {
     width: 200px;
-
     box-shadow: 0 4px 6px rgba(0,0,0,0.3);
     border-radius: 10px;
-
     object-fit: cover;
+}
+
+.slot img.center {
+    width: 250px;
 }
 
 .slotLabel {
@@ -72,4 +73,23 @@ button:hover {
     from { opacity: 0; }
     to { opacity: 1; }
 }
-#intro { margin: 10px 0 20px; font-style: italic; }
+
+@keyframes kenBurns {
+    from {
+        transform: scale(1.3) translateY(-20px);
+        opacity: 0;
+    }
+    to {
+        transform: scale(1) translateY(0);
+        opacity: 1;
+    }
+}
+
+.drawn {
+    animation: kenBurns 3s ease forwards;
+}
+
+#intro {
+    margin: 10px 0 20px;
+    font-style: italic;
+}


### PR DESCRIPTION
## Summary
- clean up merge artifacts in HTML and CSS
- animate card reveals with ken-burns style effect
- highlight present card and set as background
- reset slots on each draw

## Testing
- `npx htmlhint index.html` *(fails: needs package installation)*

------
https://chatgpt.com/codex/tasks/task_e_686dcff133cc8325ad4f109f849b98a1