### PR TITLE
Enable full-size card viewing via modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,6 +34,10 @@
         </div>
         <audio id="cardSound"></audio>
     </div>
+    <div id="imageModal" class="hidden">
+        <span id="modalClose">&times;</span>
+        <img id="modalImage" src="" alt="Full Size Card" />
+    </div>
     <script type="module" src="main.js"></script>
 </body>
 </html>

--- a/main.js
+++ b/main.js
@@ -20,6 +20,17 @@ function playSound(url) {
     audio.play();
 }
 
+function showModal(src) {
+    const modal = document.getElementById('imageModal');
+    const img = document.getElementById('modalImage');
+    img.src = src;
+    modal.classList.remove('hidden');
+}
+
+function hideModal() {
+    document.getElementById('imageModal').classList.add('hidden');
+}
+
 function resetSlots() {
     const container = document.getElementById('threeCardContainer');
     container.classList.remove('with-background');
@@ -28,6 +39,7 @@ function resetSlots() {
         const img = document.getElementById(`${slot}Image`);
         img.src = '';
         img.className = '';
+        img.onclick = null;
         document.getElementById(`${slot}Name`).textContent = '';
         const interp = document.getElementById(`${slot}Interpretation`);
         if (interp) interp.textContent = '';
@@ -39,6 +51,7 @@ async function displaySlot(slot, card) {
     const imgEl = document.getElementById(`${slot}Image`);
     imgEl.src = card.image;
     imgEl.classList.add('drawn');
+    imgEl.onclick = () => showModal(card.image);
     document.getElementById(`${slot}Name`).textContent = card.name;
     playSound(card.sound);
 
@@ -78,4 +91,8 @@ async function drawCards(cards) {
 window.addEventListener('DOMContentLoaded', async () => {
     const cards = await loadCards();
     document.getElementById('drawCards').addEventListener('click', () => drawCards(cards));
+    document.getElementById('modalClose').addEventListener('click', hideModal);
+    document.getElementById('imageModal').addEventListener('click', (e) => {
+        if (e.target.id === 'imageModal') hideModal();
+    });
 });

--- a/style.css
+++ b/style.css
@@ -105,3 +105,35 @@ button:hover {
     margin: 10px 0 20px;
     font-style: italic;
 }
+
+#imageModal {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background-color: rgba(0, 0, 0, 0.8);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    z-index: 1000;
+}
+
+#imageModal.hidden {
+    display: none;
+}
+
+#imageModal img {
+    max-width: 90%;
+    max-height: 90%;
+    border-radius: 10px;
+}
+
+#modalClose {
+    position: absolute;
+    top: 20px;
+    right: 30px;
+    font-size: 2em;
+    color: #fff;
+    cursor: pointer;
+}


### PR DESCRIPTION
## Summary
- add image modal overlay in HTML
- style modal overlay and close button
- implement show/hide modal logic in JS and attach click handlers

## Testing
- `npm --version`

------
https://chatgpt.com/codex/tasks/task_e_686dd29b70848325bfbfe536bd67a3f9