### PR TITLE
Add tarot background and GPT-4 Turbo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Afrikan Tarot
 
-A simple static web application for performing ancient Afrikan tarot readings. Card data and images live in the `assets/` folder so they can easily be replaced. The app uses the OpenAI API to fetch card interpretations if an API key is provided.
+A simple static web application for performing ancient Afrikan tarot readings. Card data and images live in the `assets/` folder so they can easily be replaced. The app uses the OpenAI API to fetch card interpretations via the GPT-4 Turbo model if an API key is provided.
 
 ## Running
 

--- a/openai.js
+++ b/openai.js
@@ -14,7 +14,7 @@ export async function getInterpretation(card) {
                 'Authorization': `Bearer ${apiKey}`
             },
             body: JSON.stringify({
-                model: 'gpt-3.5-turbo',
+                model: 'gpt-4-turbo',
                 messages: [{ role: 'user', content: prompt }],
                 max_tokens: 60
             })

--- a/style.css
+++ b/style.css
@@ -1,6 +1,11 @@
 body {
     font-family: 'Cinzel', serif;
     background-color: #7b3f00; /* rich dark orange brown */
+    background-image: url('assets/images/tarotbg.png');
+    background-size: cover;
+    background-position: center;
+    background-repeat: no-repeat;
+    background-attachment: fixed;
     color: #fff;
     text-align: center;
     margin: 0;


### PR DESCRIPTION
## Summary
- use tarotbg.png as the page's full background
- switch interpretation model to GPT-4 Turbo
- update README to mention the new model

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686dd417e8ec83259473f4c505b2b560