### PR TITLE
Switch to GPT-4o model

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Afrikan Tarot
 
-A simple static web application for performing ancient Afrikan tarot readings. Card data and images live in the `assets/` folder so they can easily be replaced. The app uses the OpenAI API to fetch card interpretations via the GPT-4 Turbo model if an API key is provided.
+A simple static web application for performing ancient Afrikan tarot readings. Card data and images live in the `assets/` folder so they can easily be replaced. The app uses the OpenAI API to fetch card interpretations via the GPT-4o model if an API key is provided.
 
 ## Running
 

--- a/openai.js
+++ b/openai.js
@@ -14,7 +14,7 @@ export async function getInterpretation(card) {
                 'Authorization': `Bearer ${apiKey}`
             },
             body: JSON.stringify({
-                model: 'gpt-4-turbo',
+                model: 'gpt-4o',
                 messages: [{ role: 'user', content: prompt }],
                 max_tokens: 60
             })


### PR DESCRIPTION
## Summary
- upgrade interpretation endpoint to use `gpt-4o`
- note the new model in README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686dd5078ac48325b1dfe243af3d9a7f