### PR TITLE
Add API key input and improved OpenAI call

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,6 +11,10 @@
     <div id="app">
         <h1>Afrikan Tarot Reading</h1>
         <p id="intro">Focus on your question and draw three cards.</p>
+        <div id="apiKeyContainer" class="hidden">
+            <input type="password" id="apiKeyInput" placeholder="OpenAI API Key" />
+            <button id="saveApiKey">Save Key</button>
+        </div>
         <button id="drawCards">Draw Cards</button>
         <div id="threeCardContainer" class="hidden">
             <div class="slot">

--- a/main.js
+++ b/main.js
@@ -85,6 +85,22 @@ async function drawCards(cards) {
 }
 
 window.addEventListener('DOMContentLoaded', async () => {
+    const apiKeyContainer = document.getElementById('apiKeyContainer');
+    const saveKeyBtn = document.getElementById('saveApiKey');
+    const apiKeyInput = document.getElementById('apiKeyInput');
+
+    if (!localStorage.getItem('OPENAI_API_KEY')) {
+        apiKeyContainer.classList.remove('hidden');
+    }
+
+    saveKeyBtn.addEventListener('click', () => {
+        const key = apiKeyInput.value.trim();
+        if (key) {
+            localStorage.setItem('OPENAI_API_KEY', key);
+            apiKeyContainer.classList.add('hidden');
+        }
+    });
+
     const cards = await loadCards();
     document.getElementById('drawCards').addEventListener('click', () => drawCards(cards));
     document.getElementById('modalClose').addEventListener('click', hideModal);

--- a/openai.js
+++ b/openai.js
@@ -1,7 +1,7 @@
 export async function getInterpretation(card) {
-    const apiKey = localStorage.getItem('OPENAI_API_KEY');
+    const apiKey = localStorage.getItem('OPENAI_API_KEY') || localStorage.getItem('ASPI_API_KEY');
     if (!apiKey) {
-        return 'Add your OpenAI API key to localStorage as OPENAI_API_KEY to get interpretations.';
+        return 'No API key found. Please save your OpenAI key to enable interpretations.';
     }
 
     const prompt = `Provide a short tarot interpretation for the card ${card.name} (traditional: ${card.traditional}).`;

--- a/style.css
+++ b/style.css
@@ -18,6 +18,20 @@ body {
     margin: 0 auto;
 }
 
+#apiKeyContainer {
+    margin: 15px 0;
+}
+
+#apiKeyContainer.hidden {
+    display: none;
+}
+
+#apiKeyInput {
+    padding: 5px;
+    border-radius: 5px;
+    margin-right: 5px;
+}
+
 h1,
 #intro {
     border: 2px solid rgba(255, 255, 255, 0.7);


### PR DESCRIPTION
## Summary
- show an API key input if no key saved
- hide the input after saving and store the key in localStorage
- check for OPENAI_API_KEY or ASPI_API_KEY before calling OpenAI
- tweak styles for the new input field

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686dda95b050832590e1177f6256835a