### PR TITLE
Add overall tarot reading interpretation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Afrikan Tarot
 
-A simple static web application for performing ancient Afrikan tarot readings. Card data and images live in the `assets/` folder so they can easily be replaced. The app uses the OpenAI API to fetch card interpretations via the GPT-4o model if an API key is provided.
+A simple static web application for performing ancient Afrikan tarot readings. Card data and images live in the `assets/` folder so they can easily be replaced. The app uses the OpenAI API to fetch card interpretations via the GPT-4o model if an API key is provided. When all three cards are drawn, their traditional names are sent to the API to obtain a fortune teller–style interpretation of the overall reading.
 
 ## Running
 

--- a/index.html
+++ b/index.html
@@ -36,6 +36,7 @@
                 <div id="futureInterpretation" class="interpretation"></div>
             </div>
         </div>
+        <div id="overallInterpretation" class="interpretation hidden"></div>
         <audio id="cardSound"></audio>
     </div>
     <div id="imageModal" class="hidden">

--- a/main.js
+++ b/main.js
@@ -1,4 +1,4 @@
-import { getInterpretation } from './openai.js';
+import { getInterpretation, getReadingInterpretation } from './openai.js';
 
 async function loadCards() {
     const res = await fetch('assets/cards.json');
@@ -40,6 +40,11 @@ function resetSlots() {
         const interp = document.getElementById(`${slot}Interpretation`);
         if (interp) interp.textContent = '';
     });
+    const overall = document.getElementById('overallInterpretation');
+    if (overall) {
+        overall.textContent = '';
+        overall.classList.add('hidden');
+    }
 }
 
 async function displaySlot(slot, card) {
@@ -82,6 +87,13 @@ async function drawCards(cards) {
         displaySlot('present', drawn[1]),
         displaySlot('future', drawn[2])
     ]);
+
+    const overall = document.getElementById('overallInterpretation');
+    if (overall) {
+        const reading = await getReadingInterpretation(drawn[0], drawn[1], drawn[2]);
+        overall.textContent = reading;
+        overall.classList.remove('hidden');
+    }
 }
 
 window.addEventListener('DOMContentLoaded', async () => {

--- a/openai.js
+++ b/openai.js
@@ -26,3 +26,32 @@ export async function getInterpretation(card) {
         return 'Failed to fetch interpretation.';
     }
 }
+
+export async function getReadingInterpretation(past, present, future) {
+    const apiKey = localStorage.getItem('OPENAI_API_KEY') || localStorage.getItem('ASPI_API_KEY');
+    if (!apiKey) {
+        return 'No API key found. Please save your OpenAI key to enable interpretations.';
+    }
+
+    const prompt = `give a fortune teller style interpretation of this tarot card reading: Past: ${past.traditional}, Present: ${present.traditional}, Future: ${future.traditional}`;
+
+    try {
+        const res = await fetch('https://api.openai.com/v1/chat/completions', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'Authorization': `Bearer ${apiKey}`
+            },
+            body: JSON.stringify({
+                model: 'gpt-4o',
+                messages: [{ role: 'user', content: prompt }],
+                max_tokens: 120
+            })
+        });
+        const data = await res.json();
+        return data.choices[0].message.content.trim();
+    } catch (e) {
+        console.error(e);
+        return 'Failed to fetch interpretation.';
+    }
+}

--- a/style.css
+++ b/style.css
@@ -168,6 +168,18 @@ button:hover {
     border-radius: 10px;
 }
 
+#overallInterpretation {
+    margin-top: 20px;
+    border: 1px solid rgba(255, 255, 255, 0.6);
+    padding: 10px;
+    border-radius: 8px;
+    background-color: rgba(0, 0, 0, 0.4);
+}
+
+#overallInterpretation.hidden {
+    display: none;
+}
+
 #modalClose {
     position: absolute;
     top: 20px;


### PR DESCRIPTION
## Summary
- send drawn card names to GPT API for overall interpretation
- show interpretation under the drawn cards
- style the overall interpretation box
- document new feature in README

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_686ddbd4abbc83258dec4de3ee2dda19