### PR TITLE
Add backend API and remove client key

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+package-lock.json
+/tmp/

--- a/README.md
+++ b/README.md
@@ -1,16 +1,19 @@
 # Afrikan Tarot
 
-A simple static web application for performing ancient Afrikan tarot readings. Card data and images live in the `assets/` folder so they can easily be replaced. The app uses the OpenAI API to fetch card interpretations via the GPT-4o model if an API key is provided. When all three cards are drawn, their traditional names are sent to the API to obtain a fortune teller–style interpretation of the overall reading.
+A simple web application for performing ancient Afrikan tarot readings. Card data and images live in the `assets/` folder so they can easily be replaced. The app uses the OpenAI API on the backend to fetch card interpretations via the GPT-4o model. When all three cards are drawn, their traditional names are sent to the API to obtain a fortune teller–style interpretation of the overall reading.
 
 ## Running
 
 This project is designed for GitHub Pages. Push the contents of this repository to a GitHub repo and enable Pages in the repository settings.
 
-Open `index.html` in a browser or visit the GitHub Pages site after deployment. Before drawing cards, store your OpenAI key in the browser console:
+Install dependencies and start the server:
 
-```javascript
-localStorage.setItem('OPENAI_API_KEY', 'sk-...');
+```bash
+npm install
+OPENAI_API_KEY=sk-... npm start
 ```
+
+The server hosts the static files and proxies requests to the OpenAI API. Visit `http://localhost:3000` in your browser to use the app.
 
 Card images should be saved in `assets/images/` and sound effects in `assets/sounds/` using the filenames referenced in `assets/cards.json`.
 If a card does not specify a sound, a short Uhadi percussion track plays when the card is drawn.

--- a/index.html
+++ b/index.html
@@ -11,10 +11,6 @@
     <div id="app">
         <h1>Afrikan Tarot Reading</h1>
         <p id="intro">Focus on your question and draw three cards.</p>
-        <div id="apiKeyContainer" class="hidden">
-            <input type="password" id="apiKeyInput" placeholder="OpenAI API Key" />
-            <button id="saveApiKey">Save Key</button>
-        </div>
         <button id="drawCards">Draw Cards</button>
         <div id="threeCardContainer" class="hidden">
             <div class="slot">

--- a/main.js
+++ b/main.js
@@ -97,22 +97,6 @@ async function drawCards(cards) {
 }
 
 window.addEventListener('DOMContentLoaded', async () => {
-    const apiKeyContainer = document.getElementById('apiKeyContainer');
-    const saveKeyBtn = document.getElementById('saveApiKey');
-    const apiKeyInput = document.getElementById('apiKeyInput');
-
-    if (!localStorage.getItem('OPENAI_API_KEY')) {
-        apiKeyContainer.classList.remove('hidden');
-    }
-
-    saveKeyBtn.addEventListener('click', () => {
-        const key = apiKeyInput.value.trim();
-        if (key) {
-            localStorage.setItem('OPENAI_API_KEY', key);
-            apiKeyContainer.classList.add('hidden');
-        }
-    });
-
     const cards = await loadCards();
     document.getElementById('drawCards').addEventListener('click', () => drawCards(cards));
     document.getElementById('modalClose').addEventListener('click', hideModal);

--- a/openai.js
+++ b/openai.js
@@ -1,26 +1,15 @@
 export async function getInterpretation(card) {
-    const apiKey = localStorage.getItem('OPENAI_API_KEY') || localStorage.getItem('ASPI_API_KEY');
-    if (!apiKey) {
-        return 'No API key found. Please save your OpenAI key to enable interpretations.';
-    }
-
-    const prompt = `Provide a short tarot interpretation for the card ${card.name} (traditional: ${card.traditional}).`;
-
     try {
-        const res = await fetch('https://api.openai.com/v1/chat/completions', {
+        const res = await fetch('/api/interpretation', {
             method: 'POST',
             headers: {
-                'Content-Type': 'application/json',
-                'Authorization': `Bearer ${apiKey}`
+                'Content-Type': 'application/json'
             },
-            body: JSON.stringify({
-                model: 'gpt-4o',
-                messages: [{ role: 'user', content: prompt }],
-                max_tokens: 60
-            })
+            body: JSON.stringify({ card })
         });
+        if (!res.ok) throw new Error('Request failed');
         const data = await res.json();
-        return data.choices[0].message.content.trim();
+        return data.interpretation;
     } catch (e) {
         console.error(e);
         return 'Failed to fetch interpretation.';
@@ -28,28 +17,17 @@ export async function getInterpretation(card) {
 }
 
 export async function getReadingInterpretation(past, present, future) {
-    const apiKey = localStorage.getItem('OPENAI_API_KEY') || localStorage.getItem('ASPI_API_KEY');
-    if (!apiKey) {
-        return 'No API key found. Please save your OpenAI key to enable interpretations.';
-    }
-
-    const prompt = `give a fortune teller style interpretation of this tarot card reading: Past: ${past.traditional}, Present: ${present.traditional}, Future: ${future.traditional}`;
-
     try {
-        const res = await fetch('https://api.openai.com/v1/chat/completions', {
+        const res = await fetch('/api/reading', {
             method: 'POST',
             headers: {
-                'Content-Type': 'application/json',
-                'Authorization': `Bearer ${apiKey}`
+                'Content-Type': 'application/json'
             },
-            body: JSON.stringify({
-                model: 'gpt-4o',
-                messages: [{ role: 'user', content: prompt }],
-                max_tokens: 120
-            })
+            body: JSON.stringify({ past, present, future })
         });
+        if (!res.ok) throw new Error('Request failed');
         const data = await res.json();
-        return data.choices[0].message.content.trim();
+        return data.interpretation;
     } catch (e) {
         console.error(e);
         return 'Failed to fetch interpretation.';

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "afrikantarot",
+  "version": "1.0.0",
+  "description": "Afrikan Tarot web application with backend API for OpenAI.",
+  "type": "module",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2"
+  }
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,64 @@
+import express from 'express';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const app = express();
+const PORT = process.env.PORT || 3000;
+const OPENAI_API_KEY = process.env.OPENAI_API_KEY;
+
+app.use(express.json());
+app.use(express.static(__dirname));
+
+async function callOpenAI(prompt, max_tokens) {
+    const res = await fetch('https://api.openai.com/v1/chat/completions', {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+            'Authorization': `Bearer ${OPENAI_API_KEY}`
+        },
+        body: JSON.stringify({
+            model: 'gpt-4o',
+            messages: [{ role: 'user', content: prompt }],
+            max_tokens
+        })
+    });
+    const data = await res.json();
+    return data.choices?.[0]?.message?.content?.trim() || 'No interpretation.';
+}
+
+app.post('/api/interpretation', async (req, res) => {
+    if (!OPENAI_API_KEY) {
+        return res.status(500).json({ error: 'API key not configured.' });
+    }
+    const { card } = req.body;
+    const prompt = `Provide a short tarot interpretation for the card ${card.name} (traditional: ${card.traditional}).`;
+    try {
+        const text = await callOpenAI(prompt, 60);
+        res.json({ interpretation: text });
+    } catch (e) {
+        console.error(e);
+        res.status(500).json({ error: 'Failed to fetch interpretation.' });
+    }
+});
+
+app.post('/api/reading', async (req, res) => {
+    if (!OPENAI_API_KEY) {
+        return res.status(500).json({ error: 'API key not configured.' });
+    }
+    const { past, present, future } = req.body;
+    const prompt = `give a fortune teller style interpretation of this tarot card reading: Past: ${past.traditional}, Present: ${present.traditional}, Future: ${future.traditional}`;
+    try {
+        const text = await callOpenAI(prompt, 120);
+        res.json({ interpretation: text });
+    } catch (e) {
+        console.error(e);
+        res.status(500).json({ error: 'Failed to fetch interpretation.' });
+    }
+});
+
+app.listen(PORT, () => {
+    console.log(`Server running on port ${PORT}`);
+});

--- a/style.css
+++ b/style.css
@@ -18,19 +18,6 @@ body {
     margin: 0 auto;
 }
 
-#apiKeyContainer {
-    margin: 15px 0;
-}
-
-#apiKeyContainer.hidden {
-    display: none;
-}
-
-#apiKeyInput {
-    padding: 5px;
-    border-radius: 5px;
-    margin-right: 5px;
-}
 
 h1,
 #intro {


### PR DESCRIPTION
## Summary
- add an Express backend that proxies OpenAI requests
- remove client side API key handling
- update README with server instructions
- add package.json and ignore node modules

## Testing
- `npm install`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686ddd519d5c83259d52a5cf0d5644e2