### PR TITLE
Enable CORS and configurable API base

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,15 @@ This project requires **Node.js 18 or later** because it relies on the built-in 
 
 You can deploy to any service that runs Node (for example Render or Vercel). Set the environment variable `OPENAI_API_KEY` and use `node server.js` as the start command.
 
-The front end expects the API routes to be served from the same origin. If the API is hosted separately you must adjust the URLs in `openai.js` and enable CORS.
+If the API lives on a different host, set `ALLOWED_ORIGINS` in the environment to a comma–separated list of origins and provide the base URL in the HTML:
+
+```html
+<script type="module" src="main.js" data-api-base="https://example.com"></script>
+```
+
+`openai.js` reads the `data-api-base` attribute (or `window.API_BASE_URL` if defined) to build the API URLs.
+
+The server enables CORS using the `ALLOWED_ORIGINS` variable, which should contain the same origins that load the front end.
 
 Card images should be saved in `assets/images/` and sound effects in `assets/sounds/` using the filenames referenced in `assets/cards.json`.
 If a card does not specify a sound, a short Uhadi percussion track plays when the card is drawn.

--- a/index.html
+++ b/index.html
@@ -39,6 +39,6 @@
         <span id="modalClose">&times;</span>
         <img id="modalImage" src="" alt="Full Size Card" />
     </div>
-    <script type="module" src="main.js"></script>
+    <script type="module" src="main.js" data-api-base=""></script>
 </body>
 </html>

--- a/openai.js
+++ b/openai.js
@@ -1,6 +1,25 @@
+let API_BASE = '';
+
+if (typeof window !== 'undefined') {
+    if (window.API_BASE_URL) {
+        API_BASE = window.API_BASE_URL;
+    } else {
+        const tag = document.querySelector('script[data-api-base]');
+        if (tag && tag.dataset.apiBase) {
+            API_BASE = tag.dataset.apiBase;
+        }
+    }
+}
+
+function buildUrl(path) {
+    if (!API_BASE) return path;
+    const base = API_BASE.endsWith('/') ? API_BASE.slice(0, -1) : API_BASE;
+    return base + path;
+}
+
 export async function getInterpretation(card) {
     try {
-        const res = await fetch('/api/interpretation', {
+        const res = await fetch(buildUrl('/api/interpretation'), {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json'
@@ -18,7 +37,7 @@ export async function getInterpretation(card) {
 
 export async function getReadingInterpretation(past, present, future) {
     try {
-        const res = await fetch('/api/reading', {
+        const res = await fetch(buildUrl('/api/reading'), {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json'

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "dotenv": "^17.1.0",
-    "express": "^4.18.2"
+    "express": "^4.18.2",
+    "cors": "^2.8.5"
   }
 }

--- a/server.js
+++ b/server.js
@@ -1,4 +1,5 @@
 import express from 'express';
+import cors from 'cors';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import dotenv from 'dotenv';
@@ -16,8 +17,14 @@ if (majorVersion < 18) {
 const app = express();
 const PORT = process.env.PORT || 3000;
 const OPENAI_API_KEY = process.env.OPENAI_API_KEY;
+const ALLOWED_ORIGINS = process.env.ALLOWED_ORIGINS?.split(',').map(o => o.trim()).filter(Boolean);
 
 app.use(express.json());
+if (ALLOWED_ORIGINS && ALLOWED_ORIGINS.length > 0) {
+    app.use(cors({ origin: ALLOWED_ORIGINS }));
+} else {
+    app.use(cors());
+}
 app.use(express.static(__dirname));
 
 async function callOpenAI(prompt, max_tokens) {


### PR DESCRIPTION
## Summary
- allow specifying allowed origins in the server via `cors`
- add `data-api-base` attribute support in `openai.js`
- document API base configuration in README
- install `cors` dependency
- expose API base attribute in `index.html`

## Testing
- `npm install`
- `node server.js`

------
https://chatgpt.com/codex/tasks/task_e_686e4b84cb688325bedab1eb26c610b5