### PR TITLE
Add deck buttons under each card

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,25 +18,28 @@
     </p>
 
     
-    <button id="drawCards">Reveal Card</button>
-        <div id="threeCardContainer" class="hidden">
+    <button id="drawCards" class="drawCards">Reveal Card</button>
+        <div id="threeCardContainer">
             <div class="slot">
                 <h3>Past</h3>
                 <p id="pastName" class="card-name"></p>
                 <img id="pastImage" src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7" alt="Past Card" />
                 <div id="pastInterpretation" class="interpretation"></div>
+                <button class="drawCards">Reveal Card</button>
             </div>
             <div class="slot">
                 <h3>Present</h3>
                 <p id="presentName" class="card-name"></p>
                 <img id="presentImage" src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7" alt="Present Card" />
                 <div id="presentInterpretation" class="interpretation"></div>
+                <button class="drawCards">Reveal Card</button>
             </div>
             <div class="slot">
                 <h3>Future</h3>
                 <p id="futureName" class="card-name"></p>
                 <img id="futureImage" src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7" alt="Future Card" />
                 <div id="futureInterpretation" class="interpretation"></div>
+                <button class="drawCards">Reveal Card</button>
             </div>
         </div>
     </div>

--- a/main.js
+++ b/main.js
@@ -1,6 +1,6 @@
 document.addEventListener('DOMContentLoaded', () => {
     // --- Get references to all HTML elements ---
-    const drawButton = document.getElementById('drawCards');
+    const drawButtons = document.querySelectorAll('.drawCards');
     const threeCardContainer = document.getElementById('threeCardContainer');
     const imageModal = document.getElementById('imageModal');
     const modalImage = document.getElementById('modalImage');
@@ -45,7 +45,7 @@ document.addEventListener('DOMContentLoaded', () => {
             interpretations = await interpretationsResponse.json();
 
             if (cards.length > 0 && interpretations.length > 0) {
-                drawButton.disabled = false;
+                drawButtons.forEach(btn => btn.disabled = false);
             } else {
                 throw new Error("Data files are empty.");
             }
@@ -73,7 +73,7 @@ document.addEventListener('DOMContentLoaded', () => {
             drawCount++;
         } else if (drawCount === 2) { // Third draw
             displayCard('Future', shuffledDeck[2], slots.future);
-            drawButton.textContent = "Shuffle Deck";
+            drawButtons.forEach(btn => btn.textContent = "Shuffle Deck");
             drawCount++;
         } else { // Reset
             resetReading();
@@ -107,8 +107,7 @@ document.addEventListener('DOMContentLoaded', () => {
             slots[position].interp.textContent = "";
         }
 
-        threeCardContainer.classList.add('hidden');
-        drawButton.textContent = "Draw Card";
+        drawButtons.forEach(btn => btn.textContent = "Draw Card");
         drawCount = 0;
         shuffledDeck = [];
     }
@@ -124,7 +123,7 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     // --- Initialize App and Event Listeners ---
-    drawButton.addEventListener('click', handleDrawClick);
+    drawButtons.forEach(btn => btn.addEventListener('click', handleDrawClick));
     modalClose.addEventListener('click', closeModal);
     imageModal.addEventListener('click', (e) => {
         if (e.target === imageModal) {
@@ -132,6 +131,6 @@ document.addEventListener('DOMContentLoaded', () => {
         }
     });
     
-    drawButton.disabled = true;
+    drawButtons.forEach(btn => btn.disabled = true);
     loadData();
 });

--- a/style.css
+++ b/style.css
@@ -97,6 +97,10 @@ button:hover {
     border-radius: 10px;
 }
 
+.slot > button {
+    margin-top: 1em;
+}
+
 .slot h3 { /* For "Past", "Present", "Future" */
     color: #fff;
     text-shadow: 1px 1px 3px rgba(0,0,0,0.7);


### PR DESCRIPTION
## Summary
- display the card placeholders on load and add a `drawCards` button beneath each
- update JS to work with multiple deck buttons
- tweak styles for the new buttons

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6886860495f083259a32fc249aaef2d7